### PR TITLE
Add alt text to the sign in button

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -18,7 +18,7 @@
     <h1>123done <span>your tasks - simplified</span></h1>
     <nav>
       <ul class="loginarea">
-        <li id="loggedout"><button><img src="img/persona-login.png"></button></li>
+        <li id="loggedout"><button><img src="img/persona-login.png" alt="Sign in with Persona"></button></li>
         <li id="loggedin">Hi, <span></span> <a href="#">logout</a></li>
         <li class="loading"><img src="img/loading.gif"></li>
     </ul>


### PR DESCRIPTION
Without this textual representation, the button is not really
visible to screen readers or to people who have images turned off.
