### PR TITLE
Move the github ribbon down in the page

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -11,8 +11,6 @@
   <script src="https://login.persona.org/include.js"></script>
 </head>
 <body>
-  <a href="https://github.com/mozilla/123done"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork 123done on GitHub"></a>
-
   <div id="container">
   <header>
     <h1>123done <span>your tasks - simplified</span></h1>
@@ -52,6 +50,8 @@
     <p>Your task list is stored on the computer for you to use. If you want to sync 123done across devices, log in with Mozilla Persona.</p>
   </section>
   <footer>
+    <a href="https://github.com/mozilla/123done"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork 123done on GitHub"></a>
+
     <p><strong>123done</strong> is a project to show the power of <a href="https://login.persona.org">Persona</a>. Written by the <a href="http://identity.mozilla.com/">identity folks</a> at Mozilla.</p>
   </footer>
   </div>


### PR DESCRIPTION
This button is the first thing that shows up in the list of
available links that screen readers produce. Moving it down the
page will allow users to find the login button more quickly.
