### PR TITLE
Update README.md to fix link to awsbok repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ and node.js.
 123done is all set up to deploy quickly and painlessly on amazon EC2 via 
 [awsbox][].
 
-  [awsbox]: https://github.com/lloyd/awsbox
+  [awsbox]: https://github.com/mozilla/awsbox
 
 While full documentation for awsbox is contained within that project, Here is a sample
 command line that might work for you:


### PR DESCRIPTION
The awsbox repo now seems to live under Mozilla's Github account, hence the need for update.
