### PR TITLE
backout 6ceb3dd4 to defer script loading; it breaks ie8

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -8,6 +8,7 @@
   <link type="text/css" rel="stylesheet" href="/en/drsugiyama/fonts.css">
   <link rel="stylesheet" href="css/styles.css" type="text/css">
   <script src="modernizr.min.js"></script>
+  <script src="https://login.persona.org/include.js"></script>
 </head>
 <body>
   <div id="container">
@@ -54,9 +55,8 @@
     <p><strong>123done</strong> is a project to show the power of <a href="https://login.persona.org">Persona</a>. Written by the <a href="http://identity.mozilla.com/">identity folks</a> at Mozilla.</p>
   </footer>
   </div>
-  <script src="js/jquery.min.js" defer></script>
-  <script src="https://login.persona.org/include.js" defer></script>
-  <script src="js/state.js" defer></script>
-  <script src="js/123done.js" defer></script>
+  <script src="js/jquery.min.js"></script>
+  <script src="js/state.js"></script>
+  <script src="js/123done.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Fixes https://github.com/mozilla/123done/issues/60 by undoing the defer of scripts.
