### PR TITLE
Use backgroundColor

### DIFF
--- a/static/js/123done.js
+++ b/static/js/123done.js
@@ -124,6 +124,7 @@ $(document).ready(function() {
         termsOfService: '/tos.txt',
         privacyPolicy: '/pp.txt',
         siteName: "123done",
+        backgroundColor: "#f5f2e4",
 // XXX: we need SSL to display a siteLogo in dialog.  Must get certificates.
 //        siteLogo: "/img/logo100.png",
         oncancel: function() {


### PR DESCRIPTION
Looks like this:

![screen shot 2013-07-10 at 5 32 45 pm](https://f.cloud.github.com/assets/24193/778431/b8b58092-e9b0-11e2-90a3-78a78e654fa9.png)

Safely ignored by the current production version of include.js.
