### PR TITLE
Fix Content-Type coming from /api/auth_status

### DIFF
--- a/server.js
+++ b/server.js
@@ -85,9 +85,9 @@ app.post('/api/verify', function(req, res) {
 // auth status reports who the currently logged in user is on this
 // session
 app.get('/api/auth_status', function(req, res) {
-  res.send(JSON.stringify({
+  res.json({
     logged_in_email: req.session.user || null,
-  }));
+  });
 });
 
 // logout clears the current authenticated user

--- a/static/js/123done.js
+++ b/static/js/123done.js
@@ -37,7 +37,7 @@ $(document).ready(function() {
 
   // now check with the server to get our current login state
   $.get('/api/auth_status', function(data) {
-    loggedInEmail = JSON.parse(data).logged_in_email;
+    loggedInEmail = data.logged_in_email;
 
     function updateUI(email) {
       $("ul.loginarea li").css('display', 'none');


### PR DESCRIPTION
Even though we were sending JSON in the body, it was being sent
with the Content-Type as 'text/html'. This fix means it'll be
sent as 'application/json'.
