### PR TITLE
add support for browserid-realm

### DIFF
--- a/server.js
+++ b/server.js
@@ -120,6 +120,13 @@ app.get('/api/todos/get', checkAuth, function(req, res) {
 });
 
 
+app.use(function(req, res, next) {
+  if (req.path === "/.well-known/browserid-realm") {
+    res.header('Content-Type', 'application/json');
+  }
+  next();
+});
+
 app.use(express.static(__dirname + "/static"));
 
 app.listen(process.env['PORT'] || 8080, '0.0.0.0');

--- a/static/.well-known/browserid-realm
+++ b/static/.well-known/browserid-realm
@@ -1,0 +1,3 @@
+{
+  "realm": ["https://sso-a.personatest.org", "https://sso-b.personatest.org"]
+}


### PR DESCRIPTION
@seanmonstar - this is what I did, with the assumption that the two domains would be called domain-a.personatest.org and domain-b.personatest.org.