### PR TITLE
Issue 87 - remove blank line before doctype for IE8's happiness

### DIFF
--- a/static/about.html
+++ b/static/about.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/static/index.html
+++ b/static/index.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
Removes blank line before doctype so that IE8 won't go into quirks mode (Issue #87)

@shane-tomlinson look ok?
