### PR TITLE
Add support for preVerifyToken generation.

### DIFF
--- a/config-local.json
+++ b/config-local.json
@@ -5,5 +5,7 @@
   "auth_uri": "http://127.0.0.1:9010/v1/authorization",
   "oauth_uri": "http://127.0.0.1:9010/v1",
   "profile_uri": "http://127.0.0.1:1111/v1",
-  "scopes": "profile"
+  "scopes": "profile",
+  "preverify_email_audience": "127.0.0.1:9000",
+  "preverify_email_jku": "http://127.0.0.1:8080/.well-known/public-keys"
 }

--- a/config.json
+++ b/config.json
@@ -5,5 +5,7 @@
   "auth_uri": "https://oauth.dev.lcip.org/v1/authorization",
   "oauth_uri": "https://oauth.dev.lcip.org/v1",
   "profile_uri": "https://profile.dev.lcip.org/v1",
-  "scopes": "profile"
+  "scopes": "profile",
+  "preverify_email_audience": "accounts.dev.lcip.org",
+  "preverify_email_jku": "https://123done.dev.lcip.org/.well-known/public-keys"
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "connect-fonts-opensans": "0.0.5",
     "connect-fonts-alegreyasans": "0.0.2",
     "request": "2.34.0",
-    "bower": "*"
+    "bower": "*",
+    "fxa-crypto-utils": "shane-tomlinson/fxa-crypto-utils"
   },
   "engines": {
     "node": ">=0.8.0"


### PR DESCRIPTION
To generate a preVerifyToken, visit `<123done_host>/api/preverify-signup?email=<email>`

@zaach, @ckarlof, @dannycoates, @seanmonstar - it's 123done with preVerifyToken support!

This is for mozilla/fxa-content-server#1606
Requires support from the auth-server too, see https://github.com/mozilla/fxa-auth-server/pull/794
