### PR TITLE
added gen_keys script for more permanent dev keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+public-key.json
+secret-key.json
 /node_modules
 static/bower_components
 *~

--- a/config.json
+++ b/config.json
@@ -1,4 +1,6 @@
 {
+  "publicKeyFile": "./public-key.json",
+  "secretKeyFile": "./secret-key.json",
   "client_id": "dcdb5ae7add825d2",
   "client_secret": "b93ef8a8f3e553a430d7e5b904c6132b2722633af9f03128029201d24a97f2a8",
   "redirect_uri": "https://123done.dev.lcip.org/api/oauth",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "connect-fonts-alegreyasans": "0.0.2",
     "request": "2.34.0",
     "bower": "*",
-    "fxa-crypto-utils": "shane-tomlinson/fxa-crypto-utils"
+    "fxa-crypto-utils": "shane-tomlinson/fxa-crypto-utils",
+    "jwcrypto": "0.4.4"
   },
   "engines": {
     "node": ">=0.8.0"

--- a/scripts/gen_keys.js
+++ b/scripts/gen_keys.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* scripts/gen_keys.js creates public and private keys suitable for
+   key signing Persona Primary IdP's.
+
+   Usage:
+   scripts/gen_keys.js
+
+   Will create these files
+
+       ./config/public-key.json
+       ./config/secret-key.json
+
+   If these files already exist, this script will show an error message
+   and exit. You must remove both keys if you want to generate a new
+   keypair.
+*/
+
+const jwcrypto = require("jwcrypto")
+const fs = require('fs')
+const assert = require("assert")
+const config = require('../config.json')
+
+const pubKeyFile = config.publicKeyFile
+const secretKeyFile = config.secretKeyFile
+
+require("jwcrypto/lib/algs/rs")
+
+try {
+  var keysExist = fs.existsSync(pubKeyFile) && fs.existsSync(secretKeyFile)
+  assert(!keysExist, "keys already exists")
+} catch(e) {
+  process.exit()
+}
+
+console.log("Generating keypair. (install libgmp if this takes more than a second)")
+
+// wondering about `keysize: 256`?
+// well, 257 = 2048bit key
+// still confused? see: https://github.com/mozilla/jwcrypto/blob/master/lib/algs/ds.js#L37-L57
+
+function main(cb) {
+  jwcrypto.generateKeypair(
+    { algorithm: 'RS', keysize: 256 },
+    function(err, keypair) {
+
+      var pubKey = keypair.publicKey.serialize()
+      var secretKey = keypair.secretKey.serialize()
+
+
+      fs.writeFileSync(pubKeyFile, pubKey)
+      console.log("Public Key saved:", pubKeyFile)
+
+      fs.writeFileSync(secretKeyFile, secretKey)
+      console.log("Secret Key saved:", secretKeyFile)
+      cb()
+    }
+  )
+}
+
+module.exports = main
+
+if (require.main === module) {
+  main(function () {})
+}


### PR DESCRIPTION
fxa-dev needs keys that persist beyond process restarts. This adds a script to generate key json files (stolen from auth-server). fxa-dev will generate the keys and have the config point at them.
