### PR TITLE
load config from location at $CONFIG_123DONE if it exists

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,4 @@
+var configFile = process.env.CONFIG_123DONE || './config.json';
+console.log('loading configuration File', configFile);
+module.exports = require(configFile);
+

--- a/oauth.js
+++ b/oauth.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var config = require('./config.json');
+var config = require('./config');
 var crypto = require('crypto');
 var request = require('request');
 var querystring = require('querystring');

--- a/scripts/gen_keys.js
+++ b/scripts/gen_keys.js
@@ -23,7 +23,7 @@
 const jwcrypto = require("jwcrypto")
 const fs = require('fs')
 const assert = require("assert")
-const config = require('../config.json')
+const config = require('../config')
 
 const pubKeyFile = config.publicKeyFile
 const secretKeyFile = config.secretKeyFile

--- a/server.js
+++ b/server.js
@@ -8,7 +8,7 @@ var express       = require('express'),
                   = require('connect-fonts-alegreyasans'),
     url           = require('url'),
     oauth         = require('./oauth'),
-    config        = require('./config.json');
+    config        = require('./config');
 
 
 


### PR DESCRIPTION
This provides a way to load the config from somewhere outside the `~app/code` directory when doing doing awsbox deploys, so configuration is preserved between code pushes. 

@zaach or @seanmonstar  - r?