### PR TITLE
feat: Add a /api/force_auth flow to allow for a programatic force_auth flow.

### DIFF
--- a/oauth.js
+++ b/oauth.js
@@ -83,6 +83,13 @@ module.exports = function(app, db) {
     });
   });
 
+  // begin a force auth flow
+  app.get('/api/force_auth', function(req, res) {
+    var nonce = generateAndSaveNonce(req);
+    var oauthInfo = getOAuthInfo('force_auth', nonce, req.query.email);
+    return res.redirect(redirectUrl(oauthInfo));
+  });
+
   app.get('/api/preverified-signup', function(req, res) {
     var email = req.query.email;
     // A real RP would do some validation on the email address


### PR DESCRIPTION
Used for functional testing the force_auth oauth flow. 

See:
* mozilla/fxa-content-server#1957
* mozilla/fxa-content-server#2019
* mozilla/fxa-oauth-server#191
* https://bugzilla.mozilla.org/show_bug.cgi?id=1104304