### PR TITLE
fix: Update fxa-relier-client to redirect off of the oauth server.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,6 @@
     "jquery": "~2.1.0",
     "normalize-css": "~3.0.1",
     "modernizr": "~2.7.2",
-    "fxa-relier-client": "https://github.com/mozilla/fxa-relier-client.git#0.0.1"
+    "fxa-relier-client": "https://github.com/mozilla/fxa-relier-client.git#0.0.2"
   }
 }

--- a/oauth.js
+++ b/oauth.js
@@ -24,6 +24,7 @@ function getOAuthInfo(action, nonce, email, preVerifyToken) {
     state: nonce,
     scope: config.scopes,
     action: action,
+    auth_uri: config.auth_uri,
     content_uri: config.content_uri
   };
 

--- a/static/js/123done.js
+++ b/static/js/123done.js
@@ -67,7 +67,8 @@ $(document).ready(function() {
         $.getJSON('/api/' + endpoint)
           .done(function (data) {
             var relierClient = new FxaRelierClient(data.client_id, {
-              fxaHost: data.content_uri
+              oauthHost: data.auth_uri,
+              contentHost: data.content_uri
             });
 
             relierClient.auth[flow]({
@@ -85,7 +86,8 @@ $(document).ready(function() {
         $.getJSON('/api/' + endpoint)
           .done(function (data) {
             var relierClient = new FxaRelierClient(data.client_id, {
-              fxaHost: data.content_uri
+              oauthHost: data.auth_uri,
+              contentHost: data.content_uri
             });
 
             relierClient.auth[flow]({


### PR DESCRIPTION
The newest fxa-relier-client bounces off the oauth server instead of going directly to the content server. To handle this, we have to pass the oauth authorization URL to the relier-client on startup.

