### PR TITLE
fix(config): config-local.json should have the same keys as config.json

### DIFF
--- a/config-local.json
+++ b/config-local.json
@@ -1,4 +1,6 @@
 {
+  "publicKeyFile": "./public-key.json",
+  "secretKeyFile": "./secret-key.json",
   "client_id": "dcdb5ae7add825d2",
   "client_secret": "b93ef8a8f3e553a430d7e5b904c6132b2722633af9f03128029201d24a97f2a8",
   "redirect_uri": "http://127.0.0.1:8080/api/oauth",


### PR DESCRIPTION
This is needed (1) just because, and (2) I can fix an issue with fxa-local-dev (not have it modify the git checked out files during installation).

@vladikoff r?