### PR TITLE
fix(app): move "choose sign-in" above signup/signin buttons

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -19,10 +19,9 @@
     <header>
       <img src="/img/transparent-logo.png" id="splash-logo" alt="123done-logo" width="72" height ="70">
       <h1>123done</h1>
-      <h2>The First Step to Greatness</h2>
+      <button class="btn btn-persona sign-choose" type="submit">Choose my sign-in flow for me</button>
       <button class="btn btn-large btn-info btn-persona sign-in-button signup" type="submit">Sign Up</button>
       <button class="btn btn-large btn-info btn-persona sign-in-button signin" type="submit">Sign In</button>
-      <button class="btn btn-persona sign-choose" type="submit">Choose my sign-in flow for me</button>
     </header>
     <section>
       <div class="container">


### PR DESCRIPTION
@vladikoff - what d'ya think? 

I've had some problems with tests failing where this button was just out of the view. This change just swaps that button in the where "The First Step..." was (what does that even mean?), and the signup/signup stay in almost the exact same position they had previously (on desktop and mobile).
