### PR TITLE
fix(ansible): cleanup fixes, and config for 123done-nightly

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,4 +1,4 @@
-The command `make stack=one23done-stage key=yourkeyname trusted_client_id="dead..." client_secret="beef..." untrusted_client_id="feed..." untrusted_client_secret="deaf..."` will create an EC2+ELB instance [1] with the following attributes:
+The command `make stack=one23done-stage key=yourkeyname trusted_client_id="dead..." trusted_client_secret="beef..." untrusted_client_id="feed..." untrusted_client_secret="deaf..."` will create an EC2+ELB instance [1] with the following attributes:
 
 * builds and runs 123done (https://github.com/mozilla/123done) webserver as both trusted (123done) and untrusted (321done), using the oauth branch
 * an AWS ELB serving both port 80, and port 443 traffic with a SSL certificate for *.dev.lcip.org

--- a/ansible/defaults.yml
+++ b/ansible/defaults.yml
@@ -5,4 +5,4 @@ region: us-west-2
 one23done_git_repo: https://github.com/mozilla/123done.git
 one23done_git_version: oauth
 hosted_zone: lcip.org
-ssl_certificate_name: exp20170412_wildcard_dev_lcip.org
+ssl_certificate_name: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381

--- a/ansible/env/one23done-nightly.yml
+++ b/ansible/env/one23done-nightly.yml
@@ -1,0 +1,8 @@
+region: us-east-1
+ssl_certificate_name: arn:aws:acm:us-east-1:927034868273:certificate/675e0ac8-23af-4153-8295-acb28ccc9f0f
+auth_uri: https://nightly-oauth.dev.lcip.org/v1/authorization
+content_uri: https://nightly.dev.lcip.org
+oauth_uri: https://nightly-oauth.dev.lcip.org/v1
+profile_uri: https://nightly-profile.dev.lcip.org/v1
+fqdn_trusted: 123done-nightly.dev.lcip.org
+fqdn_untrusted: 321done-nightly.dev.lcip.org

--- a/ansible/env/one23done-stage.yml
+++ b/ansible/env/one23done-stage.yml
@@ -1,6 +1,6 @@
-auth_uri:                 "https://oauth.stage.mozaws.net/v1/authorization"                         
-content_uri:              "https://accounts.stage.mozaws.net"
-oauth_uri:                "https://oauth.stage.mozaws.net/v1"                                      
-profile_uri:              "https://profile.stage.mozaws.net/v1"                                  
-fqdn_trusted:             "123done-stage.dev.lcip.org"
-fqdn_untrusted:           "321done-stage.dev.lcip.org"
+auth_uri: https://oauth.stage.mozaws.net/v1/authorization
+content_uri: https://accounts.stage.mozaws.net
+oauth_uri: https://oauth.stage.mozaws.net/v1
+profile_uri: https://profile.stage.mozaws.net/v1
+fqdn_trusted: 123done-stage.dev.lcip.org
+fqdn_untrusted: 321done-stage.dev.lcip.org

--- a/ansible/playbooks/roles/redis/tasks/main.yml
+++ b/ansible/playbooks/roles/redis/tasks/main.yml
@@ -1,11 +1,10 @@
 ---
 
-- name: install redis and hiredis
+- name: install redis
   sudo: true
   yum: name={{ item }} state=present enablerepo=epel
   with_items:
     - redis
-    - hiredis
 
 - name: start redis
   sudo: true

--- a/ansible/templates/app.json
+++ b/ansible/templates/app.json
@@ -30,7 +30,7 @@
     "SSLCertificateName": {
       "Description": "Name of SSLCertificate to use with HostedZone.",
       "Type": "String",
-      "ConstraintDescription": "must be a valid certificate stored in EC2."
+      "ConstraintDescription": "must be a valid certificate stored in ACM."
     },
     "FQDNTrusted": {
       "Description": "Fully qualified domain name of this trusted instance (e.g., 123done...).",
@@ -135,16 +135,8 @@
           {
             "InstancePort": "9000",
             "LoadBalancerPort": "443",
-            "PolicyNames": [ "ELBSecurityPolicy-2015-05" ],
             "Protocol": "HTTPS",
-            "SSLCertificateId":{
-              "Fn::Join":[ "", [
-                "arn:aws:iam::",
-                { "Ref": "AWS::AccountId" },
-                ":server-certificate/",
-                { "Ref": "SSLCertificateName" }
-              ] ]
-            }
+            "SSLCertificateId": { "Ref": "SSLCertificateName" }
           },
           {
             "InstancePort": "80",


### PR DESCRIPTION
r? - @vladikoff 

Mostly cleanups, but adds config for an interim {123done,321done}-nightly.dev.lcip.org that has shared, hashed client secrets with nightly-oauth.dev.lcip.org, for running tests.