### PR TITLE
feat(totp): add ability to request 2fa on login

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -24,6 +24,7 @@
       <button class="btn btn-large btn-info btn-persona signin-pkce" type="submit">Sign In with PKCE</button>
       <div class="pkce-data"></div>
       <button class="btn btn-large btn-info btn-persona email-first-button email-first" type="submit">Email first</button>
+      <button class="btn btn-large btn-info btn-persona two-step-authentication" type="submit">Sign In (Require 2FA)</button>
 
       <button class="btn btn-large btn-info btn-persona sign-in-button signup" type="submit">Sign Up</button>
       <button class="btn btn-large btn-info btn-persona sign-in-button signin" type="submit">Sign In</button>

--- a/static/js/123done.js
+++ b/static/js/123done.js
@@ -74,7 +74,7 @@ $(document).ready(function() {
     };
 
     function authenticate (endpoint) {
-      window.location.href = '/api/' + endpoint 
+      window.location.href = '/api/' + endpoint
     }
 
     $('button.signin').click(function(ev) {
@@ -94,7 +94,11 @@ $(document).ready(function() {
     });
 
     $('button.email-first').click(function(ev) {
-      authenticate('email_first');
+    	authenticate('email_first');
+    });
+
+    $('button.two-step-authentication').click(function(ev) {
+    	authenticate('two_step_authentication');
     });
 
     // upon click of logout link navigator.id.logout()


### PR DESCRIPTION
Connects to https://github.com/mozilla/fxa-oauth-server/issues/520

Fixes https://github.com/mozilla/123done/issues/172

This PR adds a button that adds the `acr_values=AAL2` param to the oauth request. This option is used in https://github.com/mozilla/fxa-content-server/pull/6545 to request TOTP.